### PR TITLE
enhanced github action (apt-get update is now necessary)

### DIFF
--- a/.github/workflows/do_listing.yml
+++ b/.github/workflows/do_listing.yml
@@ -15,8 +15,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
+    - name: apt-get update
+      run: sudo apt-get update
     - name: install dependencies (ubuntu package)
-      run: sudo apt install python3-numpy
+      run: sudo apt-get install python3-numpy
     - name: create listing
       run: env python3 list_numpy_dtypes.py
     - name: creating json output
@@ -32,8 +34,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+    - name: apt-get update
+      run: sudo apt-get update
     - name: install dependencies (ubuntu package)
-      run: sudo apt install python3-numpy
+      run: sudo apt-get install python3-numpy
     - name: create listing
       run: env python3 list_numpy_dtypes.py
     - name: creating json output


### PR DESCRIPTION
Due to a change in the ubuntu github action (see actions/virtual-environments#4136) we need to do a `apt-get update` before installing packages.
